### PR TITLE
fix: rename `foldinfo_T.rem_lines` to `lines`

### DIFF
--- a/lua/view_tween/ffi.lua
+++ b/lua/view_tween/ffi.lua
@@ -7,29 +7,29 @@ local M = {}
 ---@param winid integer
 ---@return ffi.cdata* wp # Window pointer
 function M.find_win(winid)
-  return C.find_window_by_handle(winid, M.shared.err)
+	return C.find_window_by_handle(winid, M.shared.err)
 end
 
 ---@class FoldInfo
 ---@field start integer # Line number where the deepest fold starts
 ---@field level integer # Fold level, when zero other fields are N/A
 ---@field low_level integer # Lowest fold level that starts in v:lnum
----@field rem_lines integer # Number of lines from v:lnum to end of closed fold. When 0: the fold is open
+---@field lines integer # Number of lines from v:lnum to end of closed fold. When 0: the fold is open
 
 ---@param winid integer
 ---@param lnum integer
 ---@return FoldInfo
 function M.fold_info(winid, lnum)
-  local wp = M.find_win(winid)
-  return C.fold_info(wp, lnum)
+	local wp = M.find_win(winid)
+	return C.fold_info(wp, lnum)
 end
 
 if vim.fn.has("nvim-0.8") == 1 then
-  ffi.cdef([[
+	ffi.cdef([[
   typedef int32_t linenr_T;
   ]])
 else
-  ffi.cdef([[
+	ffi.cdef([[
   typedef long linenr_T;
   ]])
 end
@@ -44,7 +44,7 @@ typedef struct {
   linenr_T start;
   int level;
   int low_level;
-  linenr_T rem_lines;
+  linenr_T lines;
 } foldinfo_T;
 
 foldinfo_T fold_info(win_T* wp, int lnum);
@@ -54,7 +54,7 @@ int plines_win_nofill(win_T *wp, linenr_T lnum, bool winheight);
 ]])
 
 M.shared = {
-  err = ffi.new("Error")
+	err = ffi.new("Error"),
 }
 M.ffi = ffi
 

--- a/lua/view_tween/init.lua
+++ b/lua/view_tween/init.lua
@@ -85,8 +85,8 @@ local function find_folds_range(winid, line_from, line_to)
   while (line_to - cur) * sign > 0 do
     fold_info = ffi.fold_info(winid, cur)
 
-    if fold_info.start ~= 0 and fold_info.rem_lines ~= 0 then
-      fold_end = cur + fold_info.rem_lines - 1
+    if fold_info.start ~= 0 and fold_info.lines ~= 0 then
+      fold_end = cur + fold_info.lines - 1
 
       if not ret[fold_info.start] then ret[fold_info.start] = {} end
       if not ret[fold_end] then ret[fold_end] = {} end
@@ -96,7 +96,7 @@ local function find_folds_range(winid, line_from, line_to)
       if sign == -1 then
         fold_edge = fold_info.start
       else
-        fold_edge = cur + fold_info.rem_lines - 1
+        fold_edge = cur + fold_info.lines - 1
       end
       cur = fold_edge + sign
     else
@@ -122,8 +122,8 @@ local function find_folds_delta(winid, line_from, delta)
   for _ = 1, math.abs(delta) do
     fold_info = ffi.fold_info(winid, cur)
 
-    if fold_info.start ~= 0 and fold_info.rem_lines ~= 0 then
-      fold_end = cur + fold_info.rem_lines - 1
+    if fold_info.start ~= 0 and fold_info.lines ~= 0 then
+      fold_end = cur + fold_info.lines - 1
 
       if not ret[fold_info.start] then ret[fold_info.start] = {} end
       if not ret[fold_end] then ret[fold_end] = {} end
@@ -133,7 +133,7 @@ local function find_folds_delta(winid, line_from, delta)
       if sign == -1 then
         fold_edge = fold_info.start
       else
-        fold_edge = cur + fold_info.rem_lines - 1
+        fold_edge = cur + fold_info.lines - 1
       end
       cur = fold_edge + sign
     else
@@ -159,7 +159,7 @@ function ViewTween:init(opt)
   self.done = false
 
   local fold_info_max = ffi.fold_info(self.winid, self.max_line)
-  if fold_info_max.start ~= 0 and fold_info_max.rem_lines ~= 0 then
+  if fold_info_max.start ~= 0 and fold_info_max.lines ~= 0 then
     self.max_line = fold_info_max.start
   end
 

--- a/lua/view_tween/utils.lua
+++ b/lua/view_tween/utils.lua
@@ -151,11 +151,11 @@ function M.get_scroll_delta(winid, line_from, line_to)
     while (line_to - cur) * sign > 0 do
       local fold_info = ffi.fold_info(winid, cur)
 
-      if fold_info.start ~= 0 and fold_info.rem_lines ~= 0 then
+      if fold_info.start ~= 0 and fold_info.lines ~= 0 then
         if sign == -1 then
           fold_edge = fold_info.start
         else
-          fold_edge = cur + fold_info.rem_lines - 1
+          fold_edge = cur + fold_info.lines - 1
         end
         cur = fold_edge + sign
       else


### PR DESCRIPTION
I know this is meant only for your config, but I've tried it out and it works great except for this issue where `foldinfo_T.rem_lines` causes an error but `lines` does not. Just figured I'd submit this here as this was the change I made to get it working.